### PR TITLE
Bump analyzer 6.0.0

### DIFF
--- a/hive_built_value/example/lib/main.g.dart
+++ b/hive_built_value/example/lib/main.g.dart
@@ -16,11 +16,8 @@ class PersonAdapter extends TypeAdapter<Person> {
     final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return Person(
-      name: fields[0] as String,
-      age: fields[1] as int,
-      friends: (fields[2] as List).cast<String>(),
-    );
+
+    ;
   }
 
   @override

--- a/hive_built_value/example/pubspec.yaml
+++ b/hive_built_value/example/pubspec.yaml
@@ -1,10 +1,12 @@
 name: example
 
 dependencies:
-  hive_built_value: ^2.0.10
+  hive_built_value:
+    path: ../../hive_built_value
 
 dev_dependencies:
-  hive_built_value_generator: ^1.1.8
+  hive_built_value_generator:
+    path: ../../hive_built_value_generator
   build_runner: ^2.3.3
 
 environment:

--- a/hive_built_value/pubspec.yaml
+++ b/hive_built_value/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.2
-  meta: 1.15.0
+  meta: ^1.8.0
 
 dev_dependencies:
   test: ^1.24.2

--- a/hive_built_value/pubspec.yaml
+++ b/hive_built_value/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.2
-  meta: 1.8.0
+  meta: 1.15.0
 
 dev_dependencies:
   test: ^1.24.2

--- a/hive_built_value_flutter/pubspec.yaml
+++ b/hive_built_value_flutter/pubspec.yaml
@@ -23,4 +23,4 @@ dev_dependencies:
   build_runner: ^2.3.3
 
 dependency_overrides:
-  meta: 1.8.0
+  meta: ^1.8.0

--- a/hive_built_value_flutter/pubspec.yaml
+++ b/hive_built_value_flutter/pubspec.yaml
@@ -11,7 +11,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  hive_built_value: ^2.3.0
+  hive_built_value:
+    path: ../hive_built_value
   path_provider: ^2.0.14
   path: ^1.8.2
 

--- a/hive_built_value_generator/example/pubspec.yaml
+++ b/hive_built_value_generator/example/pubspec.yaml
@@ -9,7 +9,7 @@ dev_dependencies:
     path: ../../hive_built_value_flutter
 
 dependency_overrides:
-  meta: 1.8.0
+  meta: ^1.8.0
 
 environment:
   sdk: ">=2.17.6 <3.0.0"

--- a/hive_built_value_generator/example/pubspec.yaml
+++ b/hive_built_value_generator/example/pubspec.yaml
@@ -3,8 +3,10 @@ dependencies:
   hive: any
 dev_dependencies:
   build_runner: 2.3.3
-  hive_built_value: ^2.0.10
-  hive_built_value_flutter: ^1.1.2
+  hive_built_value:
+    path: ../../hive_built_value
+  hive_built_value_flutter:
+    path: ../../hive_built_value_flutter
 
 dependency_overrides:
   meta: 1.8.0

--- a/hive_built_value_generator/pubspec.yaml
+++ b/hive_built_value_generator/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   source_gen: ^1.2.7
   hive_built_value:
     path: ../hive_built_value
-  analyzer: 6.0.0
+  analyzer: ^6.0.0
   source_helper: ^1.3.3
   dartx: ^1.1.0
   built_value: ^8.4.4

--- a/hive_built_value_generator/pubspec.yaml
+++ b/hive_built_value_generator/pubspec.yaml
@@ -10,8 +10,9 @@ environment:
 dependencies:
   build: ^2.3.1
   source_gen: ^1.2.7
-  hive_built_value: ^2.3.0
-  analyzer: ^5.11.1
+  hive_built_value:
+    path: ../hive_built_value
+  analyzer: 6.0.0
   source_helper: ^1.3.3
   dartx: ^1.1.0
   built_value: ^8.4.4


### PR DESCRIPTION
The current project is not usable with `analyzer 6.0.0` dependency which causes a lot of conflicts when you try to update build value dependencies.

Done:
- Redefine all children modules to use the local code instead of remote versions, some of them were inconsistent with the latest version.
- Update analyzer and meta which is a dependency of analyzer